### PR TITLE
[Improvement] SYST-674: Generate `RSS` inside of `Systatum` gatsby

### DIFF
--- a/apps/systatum/gatsby-node.ts
+++ b/apps/systatum/gatsby-node.ts
@@ -3,6 +3,7 @@ import type { GatsbyNode } from "gatsby";
 import client from "./tina/__generated__/client";
 import fs from "fs";
 import RSS from "rss";
+import { generateDescription } from "./src/seo/metadata";
 
 export const onCreateWebpackConfig: GatsbyNode["onCreateWebpackConfig"] = ({
   actions,
@@ -48,7 +49,7 @@ export const createPages: GatsbyNode["createPages"] = async ({ actions }) => {
         relativePath,
         meta: {
           title: post?.title ?? "",
-          description: post?.excerpt ?? "",
+          description: generateDescription(post?.excerpt, post?._body),
           image: post?.heroImg ?? "",
         },
       },
@@ -85,7 +86,7 @@ export const onPostBuild: GatsbyNode["onPostBuild"] = async () => {
 
     feed.item({
       title: post?.title ?? "",
-      description: post?.excerpt ?? "",
+      description: generateDescription(post?.excerpt, post?._body),
       url: `https://systatum.com/post/${locale}/${slug}`,
       date: post?.date ?? new Date().toISOString(),
     });

--- a/apps/systatum/src/fragments/post/client-page.tsx
+++ b/apps/systatum/src/fragments/post/client-page.tsx
@@ -54,6 +54,14 @@ export function PostsClientPage(props: ClientPostProps) {
     typeof window !== "undefined" ? window.location.pathname : "";
   const isPostPage = pathname.startsWith("/post");
 
+  const isActiveCategory = (path: string) => {
+    if (path === "/post") {
+      return !categoryPost;
+    }
+
+    return path === `/post?category=${categoryPost}`;
+  };
+
   const posts: PostItem[] = (props.data?.postConnection.edges ?? [])
     .filter((edge) => edge?.node?._sys?.relativePath?.startsWith(locale))
 
@@ -192,6 +200,11 @@ export function PostsClientPage(props: ClientPostProps) {
                         border-color: #045e95;
                         transition: all ease-in-out 0.2s;
                       }
+
+                      ${isActiveCategory(item.path) &&
+                      css`
+                        border-color: #045e95;
+                      `}
                     `,
                   }}
                   caption={item.label}

--- a/apps/systatum/src/seo/metadata.tsx
+++ b/apps/systatum/src/seo/metadata.tsx
@@ -51,3 +51,41 @@ export function createMetadata({
     </>
   );
 }
+
+// Convert TinaCMS rich-text JSON into plain text
+export const richTextToPlainText = (node: any): string => {
+  if (!node) return "";
+
+  if (node.type === "text") {
+    return node.text || "";
+  }
+
+  if (Array.isArray(node.children)) {
+    return node.children.map(richTextToPlainText).join("");
+  }
+
+  return "";
+};
+
+// Generate RSS description from excerpt or content
+export const generateDescription = (
+  excerpt: any,
+  body: any,
+  maxParagraphs = 2,
+) => {
+  // Use excerpt first if available
+  const excerptText = richTextToPlainText(excerpt).trim();
+
+  if (excerptText) {
+    return excerptText;
+  }
+
+  const paragraphs =
+    body?.children
+      .filter((child: any) => child.type === "p")
+      .slice(0, maxParagraphs)
+      .map((paragraph: any) => richTextToPlainText(paragraph).trim())
+      .filter(Boolean) || [];
+
+  return paragraphs.join("\n\n");
+};


### PR DESCRIPTION
Previously, when open the `systatum.com/rss.xml`, the description were not rendered properly inside the RSS Feed. 

This pull request improves the RSS description generation logic by prioritizing the excerpt first, then falling back to the content body and limiting the generated description to the first two paragraphs.

Before:
<img width="1435" height="584" alt="Screenshot 2026-05-08 at 16 42 06" src="https://github.com/user-attachments/assets/5339ca78-1ef7-45e7-a813-c74c93bc097c" />

After:
<img width="1232" height="1194" alt="image" src="https://github.com/user-attachments/assets/3060b1db-dce2-4492-a8eb-aadd39c9474a" />

