### PR TITLE
[Improvement] SYST-678: Reword systatum copywriting

### DIFF
--- a/apps/systatum/src/fragments/homepage/collaborate-and-email-section.tsx
+++ b/apps/systatum/src/fragments/homepage/collaborate-and-email-section.tsx
@@ -36,7 +36,7 @@ export function CollaborateAndEmail() {
           </div>
           <div
             aria-label="title-and-description"
-            className="relative flex flex-col gap-6 md:gap-10 md:max-w-125"
+            className="relative flex flex-col gap-4.25 md:max-w-125"
           >
             <h3 className="font-semibold text-3xl sm:text-4xl md:text-5xl">
               {tCollab("title")}

--- a/apps/systatum/src/i18n/messages/en-US.json
+++ b/apps/systatum/src/i18n/messages/en-US.json
@@ -47,8 +47,8 @@
       }
     },
     "collaborateAndEmailSection": {
-      "title": "Our work ethics and solutions can thrive in your organizations, too.",
-      "subtitle": "We are open to collaboration requests, such as to develop a software peculiar to your needs, or in other avenues we can pour our Systatum energy into.",
+      "title": "Work with us",
+      "subtitle": "We are open to collaboration opportunities, whether it involves developing software tailored to your specific needs or contributing across areas where our expertise can be of value — including React, Electron, Ruby, Crystal, Python, Go, mobile development, web design, and more. Through every collaboration, we strive to provide thoughtful solutions, dependable work ethics, and meaningful contributions to the organizations we work with.",
       "labelFormName": "Name",
       "validationErrorFormName": "Name must be at least 3 characters long",
       "labelFormEmail": "Email",

--- a/apps/systatum/src/i18n/messages/id-ID.json
+++ b/apps/systatum/src/i18n/messages/id-ID.json
@@ -47,8 +47,8 @@
       }
     },
     "collaborateAndEmailSection": {
-      "title": "Etika kerja dan solusi kami juga bisa berkembang di organisasimu.",
-      "subtitle": "Kami terbuka untuk permintaan kolaborasi, seperti mengembangkan perangkat lunak sesuai kebutuhanmu, atau melalui cara lain di mana kami bisa menuangkan energi Systatum.",
+      "title": "Bekerja bersama kami",
+      "subtitle": "Kami senang terlibat dalam berbagai bentuk kolaborasi, mulai dari pengembangan software sesuai kebutuhan, hingga membantu mewujudkan ide dan produk digital di berbagai bidang. Keahlian kami mencakup React, Electron, Ruby, Crystal, Python, Go, mobile development, web design, dan banyak lagi. Dalam setiap kerja sama, kami mengutamakan komunikasi yang baik, proses kerja yang dapat diandalkan, dan hasil yang benar-benar membawa manfaat.",
       "labelFormName": "Nama",
       "validationErrorFormName": "Nama harus memiliki minimal 3 karakter",
       "labelFormEmail": "Email",

--- a/apps/systatum/src/i18n/messages/ja-JP.json
+++ b/apps/systatum/src/i18n/messages/ja-JP.json
@@ -47,8 +47,8 @@
       }
     },
     "collaborateAndEmailSection": {
-      "title": "私たちの労働倫理とソリューションは、あなたの組織でも活かすことができます。",
-      "subtitle": "私たちはコラボレーションの依頼にオープンです。例えば、あなたのニーズに合わせたソフトウェアの開発や、Systatumのエネルギーを注ぎ込める他の領域でも。",
+      "title": "私たちと働きませんか",
+      "subtitle": "お客様のニーズに合わせたソフトウェア開発をはじめ、React、Electron、Ruby、Crystal、Python、Go、モバイル開発、Webデザインなど、幅広い分野で協力の機会を歓迎しています。あらゆるプロジェクトにおいて、誠実な姿勢と確かな技術力をもって、価値あるソリューションと貢献を提供できるよう努めています。",
       "labelFormName": "名前",
       "validationErrorFormName": "名前は3文字以上で入力してください",
       "labelFormEmail": "メールアドレス",


### PR DESCRIPTION
Description:
This pull request improves the `title` and `description` in the `Collaborator and Email` section of the `Systatum` landing page.

The content has been revised across English, Japanese, and Indonesian locales to better communicate Systatum's opennes to collaboration opportunities and highlight the team's expertise across software development, design, and technical fields.

English:
- Work with us
- We are open to collaboration opportunities, whether it involves developing software tailored to your specific needs or contributing across areas where our expertise can be of value — including React, Electron, Ruby, Crystal, Python, Go, mobile development, web design, and more. Through every collaboration, we strive to provide thoughtful solutions, dependable work ethics, and meaningful contributions to the organizations we work with.

Japanese:
- 私たちと働きませんか
- お客様のニーズに合わせたソフトウェア開発をはじめ、React、Electron、Ruby、Crystal、Python、Go、モバイル開発、Webデザインなど、幅広い分野で協力の機会を歓迎しています。あらゆるプロジェクトにおいて、誠実な姿勢と確かな技術力をもって、価値あるソリューションと貢献を提供できるよう努めています。

Indonesian:
- Bekerja bersama kami
- Kami senang terlibat dalam berbagai bentuk kolaborasi, mulai dari pengembangan software sesuai kebutuhan, hingga membantu mewujudkan ide dan produk digital di berbagai bidang. Keahlian kami mencakup React, Electron, Ruby, Crystal, Python, Go, mobile development, web design, dan banyak lagi. Dalam setiap kerja sama, kami mengutamakan komunikasi yang baik, proses kerja yang dapat diandalkan, dan hasil yang benar-benar membawa manfaat.

Source:
[[Improvement] SYST-678: Reword systatum copywriting](https://linear.app/systatum/issue/SYST-678/reword-systatum-copywriting)