### PR TITLE
[Bug] SYST-780: `TinaCMS` can't open on `systatum/admin`

### DIFF
--- a/apps/systatum/netlify.toml
+++ b/apps/systatum/netlify.toml
@@ -16,6 +16,12 @@
 [build.environment]
   GATSBY_PRESERVE_FILE_DOWNLOAD_CACHE = "true"
 
+[[headers]]
+  for = "/*"
+
+  [headers.values]
+  Content-Security-Policy = "frame-ancestors 'self' https://app.tina.io;"
+
 [[redirects]]
   from = "/*"
   to = "/index.html"  


### PR DESCRIPTION
This ticket fixes the `X-Frame-Options: DENY` error that occurs when using TinaCMS in the Systatum Admin.

The issue is caused by the application sending the `X-Frame-Options: DENY` header, which prevents the site from being embedded inside the TinaCMS iframe. This behavior appears to be related to security header changes introduced by either `TinaCMS`, `Gatsby`, or the `hosting-platform`. If the appropriate headers are not configured, the TinaCMS admin interface cannot load correctly.

Reference: https://answers.netlify.com/t/breaking-change-x-frame-options-set-to-deny/102220/2

We can use this:

```
[[headers]]
  for = "/*"

  [headers.values]
  Content-Security-Policy = "frame-ancestors 'self' https://app.tina.io;"
```

This configuration allows the site to be embedded only by `https://app.tina.io` (and the site itself (`systatum.com`)), maintaining security while enabling the TinaCMS admin interface to function correctly.