### PR TITLE
[Bug] SYST-781: Process H2, H3, appropriately on blog post

### DIFF
--- a/apps/systatum/src/fragments/post/detail/client-page.tsx
+++ b/apps/systatum/src/fragments/post/detail/client-page.tsx
@@ -36,7 +36,7 @@ export default function PostClientPage(props: ClientPostProps) {
 
   return (
     <ErrorBoundary>
-      <Section className="pt-2 pb-14 px-5 sm:px-8">
+      <Section className="pt-2 pb-14 px-5 sm:px-8 blog-post">
         <div className="flex flex-col gap-10 md:max-w-4xl max-w-xl mx-auto">
           <div className="flex flex-row w-fit mx-auto">
             <Crumb

--- a/apps/systatum/src/styles/globals.css
+++ b/apps/systatum/src/styles/globals.css
@@ -257,3 +257,30 @@ body {
     font-weight: 500;
   }
 }
+
+.blog-post pre {
+  background-color: #f8f8f8;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  padding: 1rem;
+  overflow-x: auto;
+  font-family: ui-monospace, SFMono-Regular, "Roboto Mono", monospace;
+  font-size: 0.9rem;
+  line-height: 1.6;
+}
+
+.blog-post pre code {
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: #24292f;
+}
+
+.blog-post code:not(pre code) {
+  background-color: #f3f4f6;
+  color: rgb(227, 17, 108);
+  border-radius: 4px;
+  padding: 0.15rem 0.35rem;
+  font-family: ui-monospace, SFMono-Regular, "Roboto Mono", monospace;
+  font-size: 0.9em;
+}

--- a/apps/systatum/src/styles/globals.css
+++ b/apps/systatum/src/styles/globals.css
@@ -235,3 +235,25 @@ body {
       20px 0 rgba(20, 99, 255, 0.6);
   }
 }
+
+.blog-post h2 {
+  font-size: 24px;
+  font-weight: 500;
+}
+
+.blog-post h3 {
+  font-size: 20px;
+  font-weight: 500;
+}
+
+@media (max-width: 450px) {
+  .blog-post h2 {
+    font-size: 20px;
+    font-weight: 500;
+  }
+
+  .blog-post h3 {
+    font-size: 16px;
+    font-weight: 500;
+  }
+}

--- a/apps/systatum/src/styles/globals.css
+++ b/apps/systatum/src/styles/globals.css
@@ -236,25 +236,41 @@ body {
   }
 }
 
+.blog-post h1 {
+  font-size: 36px;
+  font-weight: 600;
+}
+
 .blog-post h2 {
+  font-size: 30px;
+  font-weight: 600;
+}
+
+.blog-post h3 {
   font-size: 24px;
   font-weight: 500;
 }
 
-.blog-post h3 {
+.blog-post h4 {
   font-size: 20px;
   font-weight: 500;
 }
 
 @media (max-width: 450px) {
+  .blog-post h1 {
+    font-size: 28px;
+  }
+
   .blog-post h2 {
-    font-size: 20px;
-    font-weight: 500;
+    font-size: 24px;
   }
 
   .blog-post h3 {
-    font-size: 16px;
-    font-weight: 500;
+    font-size: 20px;
+  }
+
+  .blog-post h4 {
+    font-size: 18px;
   }
 }
 

--- a/apps/systatum/src/styles/globals.css
+++ b/apps/systatum/src/styles/globals.css
@@ -236,45 +236,44 @@ body {
   }
 }
 
-.blog-post h1 {
-  font-size: 36px;
-  font-weight: 600;
+.blog-post .prose h1 {
+  font-size: 28px;
+  font-weight: 500;
 }
 
-.blog-post h2 {
-  font-size: 30px;
-  font-weight: 600;
-}
-
-.blog-post h3 {
+.blog-post .prose h2 {
   font-size: 24px;
   font-weight: 500;
 }
 
-.blog-post h4 {
+.blog-post .prose h3 {
   font-size: 20px;
   font-weight: 500;
 }
 
-@media (max-width: 450px) {
-  .blog-post h1 {
-    font-size: 28px;
-  }
+.blog-post .prose h4 {
+  font-size: 16px;
+  font-weight: 500;
+}
 
-  .blog-post h2 {
+@media (max-width: 450px) {
+  .blog-post .prose h1 {
     font-size: 24px;
   }
-
-  .blog-post h3 {
+  .blog-post .prose h2 {
     font-size: 20px;
   }
 
-  .blog-post h4 {
-    font-size: 18px;
+  .blog-post .prose h3 {
+    font-size: 16px;
+  }
+
+  .blog-post .prose h4 {
+    font-size: 12px;
   }
 }
 
-.blog-post pre {
+.blog-post .prose pre {
   background-color: #f8f8f8;
   border: 1px solid #e5e7eb;
   border-radius: 8px;
@@ -285,14 +284,14 @@ body {
   line-height: 1.6;
 }
 
-.blog-post pre code {
+.blog-post .prose pre code {
   background: transparent;
   border: none;
   padding: 0;
   color: #24292f;
 }
 
-.blog-post code:not(pre code) {
+.blog-post .prose code:not(pre code) {
   background-color: #f3f4f6;
   color: rgb(227, 17, 108);
   border-radius: 4px;


### PR DESCRIPTION
Description:
This pull request fixes the `H2`, `H3` to use properly `font-size`, `font-weight`, and for uses on the `code`, and `pre:code` in the `Systatum` homepage.

Source:
[[Bug] SYST-781: Process H2, H3, appropriately on blog post](https://linear.app/systatum/issue/SYST-781/process-h2-h3-appropriately-on-blog-post)